### PR TITLE
don't crash when no string validators specified

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -172,7 +172,7 @@ var generateValidationLanguage = function(self, validations, context) {
 
       return v;
     }),
-    validation: valueValidations.join(' || ')
+    validation: (valueValidations.length > 0 ? valueValidations.join(' || ') : 'true')
   }); 
 }
 


### PR DESCRIPTION
Right now, if you don't specify any validations for strings, you get a really long esprima stack trace with `Error: Line 66: Unexpected token &&` because the actual generated code looks like `if (() && context.failOnFirst) {}`.
